### PR TITLE
Multiple bug fixes

### DIFF
--- a/TestAssemblyLoadContext.cs
+++ b/TestAssemblyLoadContext.cs
@@ -10,7 +10,7 @@ internal class TestAssemblyLoadContext : AssemblyLoadContext {
     
     private readonly AssemblyDependencyResolver _resolver;
 
-    internal TestAssemblyLoadContext(string baseAssemblyPath) : base(isCollectible: true) {
+    internal TestAssemblyLoadContext(string baseAssemblyPath, bool isCollectible) : base(isCollectible) {
         _resolver = new AssemblyDependencyResolver(baseAssemblyPath);
     }
     

--- a/TestClassInterceptor.cs
+++ b/TestClassInterceptor.cs
@@ -1,6 +1,5 @@
 ﻿using System.Reflection;
 using System.Reflection.Emit;
-using Microsoft.VisualBasic;
 using NLog;
 using UnsafeCLR;
 
@@ -78,6 +77,16 @@ internal class TestClassInterceptor {
 
     internal bool DisposeOfObjects() {
         Logger.Trace("Begin DisposeOfObjects for isolated type {0}", _executingContextTestType.FullName);
+        if (_testMethodCount == 0) {
+            Logger.Trace("Could not detect a test method in the isolated test {0}, disposing...", _executingContextTestType.FullName);
+            return true;
+        }
+        
+        if (!_loaded) {
+            Logger.Trace("Skipping disposal of objects as type {0} is not yet loaded", _executingContextTestType.FullName);
+            return false;
+        }
+        
         var collectedObjects = _objectToProxy.Where(x => !x.Item1.IsAlive)
             .ToList();
         

--- a/TestIsolator.cs
+++ b/TestIsolator.cs
@@ -9,7 +9,7 @@ public static class TestIsolator {
 
     private const string LoadedEnvVariableName = "ISOLATED_TESTS_LOADED";
     
-    public static void ModuleInitializer() {
+    public static void ModuleInitializer(bool collectibleAssemblies = true) {
         var variable = Environment.GetEnvironmentVariable(LoadedEnvVariableName);
         if (variable != null) {
             // This assembly is being run as an isolated test, we already did
@@ -23,7 +23,7 @@ public static class TestIsolator {
         var callingAssembly = Assembly.GetCallingAssembly();
         var testInterceptors = callingAssembly.GetTypes()
             .Where(t => t.IsClass && t.GetCustomAttributes(typeof(IsolatedTestAttribute), true).Length > 0)
-            .Select(t => new TestClassInterceptor(t))
+            .Select(t => new TestClassInterceptor(t, collectibleAssemblies))
             .ToList();
 
         var watcher = new InterceptorWatcher(testInterceptors);

--- a/Tests/Attribute/MyTestCleanerAttribute.cs
+++ b/Tests/Attribute/MyTestCleanerAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace Tests.Attribute;
+
+[AttributeUsage(AttributeTargets.Method)]
+internal class MyTestCleanerAttribute : System.Attribute {
+    
+}

--- a/Tests/Attribute/MyTestInitializerAttribute.cs
+++ b/Tests/Attribute/MyTestInitializerAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace Tests.Attribute;
+
+[AttributeUsage(AttributeTargets.Method)]
+internal class MyTestInitializerAttribute : System.Attribute {
+    
+}

--- a/Tests/Attribute/MyTestMethodAttribute.cs
+++ b/Tests/Attribute/MyTestMethodAttribute.cs
@@ -1,0 +1,6 @@
+﻿namespace Tests.Attribute;
+
+[AttributeUsage(AttributeTargets.Method)]
+internal class MyTestMethodAttribute : System.Attribute {
+    
+}

--- a/Tests/TestClassInterceptorTest.cs
+++ b/Tests/TestClassInterceptorTest.cs
@@ -6,7 +6,7 @@ namespace Tests;
 [TestClass]
 public class TestClassInterceptorTests {
 
-    private const string ValidTestClassCode = @"
+    private const string ValidTestClassCodeTemplate = @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -14,21 +14,21 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace TestClassInterceptorTests;
 
 [TestClass]
-public class ValidTestClass {
+public class ValidTestClass_{0} {{
 
     [TestMethod]
-    public void TestMethod() {
+    public void TestMethod() {{
         Assert.AreEqual(2 + 2, 4);
-    }
+    }}
 
     [TestMethod]
-    public async void TestAsyncMethod() {
+    public async void TestAsyncMethod() {{
         await Task.Delay(1);
         Assert.AreEqual(2 + 2, 4);
-    }
-}";
+    }}
+}}";
     
-    private const string InvalidTestClassesCode = @"
+    private const string InvalidTestClassesCodeTemplate = @"
 using System;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -36,32 +36,58 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace TestClassInterceptorTests;
 
 [TestClass]
-public class InvalidTestMethodWithReturn {
+public class InvalidTestMethodWithReturn_{0} {{
 
     [TestMethod]
-    public int TestMethodWithReturn() {
+    public int TestMethodWithReturn() {{
         Assert.AreEqual(2 + 2, 4);
         return 1;
-    }
+    }}
 
-}
+}}
 
 [TestClass]
-public class InvalidTestMethodWithParameters {
+public class InvalidTestMethodWithParameters_{0} {{
 
     [TestMethod]
-    public void TestMethodWithParameters(int param) {
+    public void TestMethodWithParameters(int param) {{
         Assert.AreEqual(2 + 2, 4);
-    }
+    }}
 
-}";
+}}";
     
-    private static readonly Assembly ValidTestClassAssembly = TestHelpers.CompileCode(ValidTestClassCode);
-    private static readonly Assembly InvalidTestClassAssembly = TestHelpers.CompileCode(InvalidTestClassesCode);
+    private const string UnsupportedTestClassesCodeTemplate = @"
+using System;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+namespace TestClassInterceptorTests;
+
+//[UnsupportedTestAttribute]
+public class UnsupportedTest_{0} {{
+
+    //[UnsupportedTestAttribute]
+    public void TestMethod() {{
+        Assert.AreEqual(2 + 2, 4);
+    }}
+
+}}";
+    
+
+    private static int _currentClassId;
+
+    private static Tuple<Assembly, int> TestClassAssemblyProvider(string codeTemplate) {
+        var classId = ++_currentClassId;
+        var code = string.Format(codeTemplate, classId);
+        var assembly = TestHelpers.CompileCode(code);
+        return new Tuple<Assembly, int>(assembly, classId);
+    }
+    
     [TestMethod]
     public void TestShouldAcceptValidClass() {
-        var type = ValidTestClassAssembly.GetType("TestClassInterceptorTests.ValidTestClass");
+        var (assembly, classId) = TestClassAssemblyProvider(ValidTestClassCodeTemplate);
+        var typeName = $"TestClassInterceptorTests.ValidTestClass_{classId}";
+        var type = assembly.GetType(typeName);
         Assert.IsNotNull(type);
         
         try {
@@ -74,7 +100,9 @@ public class InvalidTestMethodWithParameters {
 
     [TestMethod]
     public void TestShouldNotAcceptMethodWithReturn() {
-        var type = InvalidTestClassAssembly.GetType("TestClassInterceptorTests.InvalidTestMethodWithReturn");
+        var (assembly, classId) = TestClassAssemblyProvider(InvalidTestClassesCodeTemplate);
+        var typeName = $"TestClassInterceptorTests.InvalidTestMethodWithReturn_{classId}";
+        var type = assembly.GetType(typeName);
         Assert.IsNotNull(type);
         
         var exception = Assert.ThrowsException<InvalidOperationException>(() => _ = new TestClassInterceptor(type));
@@ -83,10 +111,34 @@ public class InvalidTestMethodWithParameters {
 
     [TestMethod]
     public void TestShouldNotAcceptMethodWithParameters() {
-        var type = InvalidTestClassAssembly.GetType("TestClassInterceptorTests.InvalidTestMethodWithParameters");
+        var (assembly, classId) = TestClassAssemblyProvider(InvalidTestClassesCodeTemplate);
+        var typeName = $"TestClassInterceptorTests.InvalidTestMethodWithParameters_{classId}";
+        var type = assembly.GetType(typeName);
         Assert.IsNotNull(type);
         
         var exception = Assert.ThrowsException<NotSupportedException>(() => _ = new TestClassInterceptor(type));
         Assert.AreEqual("Isolated test TestMethodWithParameters should not have parameters", exception.Message);
+    }
+
+    [TestMethod]
+    public void TestDisposeOfObjectsShouldReturnTrueWhenNoTestMethodFound() {
+        var (assembly, classId) = TestClassAssemblyProvider(UnsupportedTestClassesCodeTemplate);
+        var typeName = $"TestClassInterceptorTests.UnsupportedTest_{classId}";
+        var type = assembly.GetType(typeName);
+        Assert.IsNotNull(type);
+        
+        var interceptor = new TestClassInterceptor(type);
+        Assert.IsTrue(interceptor.DisposeOfObjects());
+    }
+
+    [TestMethod]
+    public void TestDisposeOfObjectsShouldReturnFalseWhenNotInitialized() {
+        var (assembly, classId) = TestClassAssemblyProvider(ValidTestClassCodeTemplate);
+        var typeName = $"TestClassInterceptorTests.ValidTestClass_{classId}";
+        var type = assembly.GetType(typeName);
+        Assert.IsNotNull(type);
+        
+        var interceptor = new TestClassInterceptor(type);
+        Assert.IsFalse(interceptor.DisposeOfObjects());
     }
 }


### PR DESCRIPTION
- Fixed a bug where isolating a test with unknown test attributes would make `DisposeOfObjects` crash.
- Fixed a bug where if an isolated instance was already created (by `[TestInitialize]` for example), the instance which is used for `[TestMethod]` was not the same.
- Added the possibility to specify whether the `LoadAssemblyContext` used to isolate tests should be collectible or not. (**True by default**)